### PR TITLE
Replace deprecated OpaqueToken with InjectionToken

### DIFF
--- a/src/lib/http-factory.token.ts
+++ b/src/lib/http-factory.token.ts
@@ -1,3 +1,4 @@
-import { OpaqueToken } from "@angular/core";
+import { InjectionToken } from "@angular/core";
+import { HttpFactory } from "./interfaces/HttpFactory";
 
-export const HTTP_FACTORY = new OpaqueToken("Http implementation factory");
+export const HTTP_FACTORY = new InjectionToken<HttpFactory>("Http implementation factory");


### PR DESCRIPTION
OpaqueToken is deprecated as of angular/core 4.0.0; fixes #15.